### PR TITLE
Allow Equivalent option with mutally exclusive OptionFlag.

### DIFF
--- a/clang/lib/Driver/DriverOptions.cpp
+++ b/clang/lib/Driver/DriverOptions.cpp
@@ -29,12 +29,23 @@ static const OptTable::Info InfoTable[] = {
 #undef OPTION
 };
 
+// 2 options with different mutually exclusive flags will not happen at same
+// time.
+static const unsigned MutuallyExclusiveFlags[] = {
+    clang::driver::options::ClangFlags::CC1Option,
+    clang::driver::options::ClangFlags::CLOption,
+    clang::driver::options::ClangFlags::CoreOption,
+    clang::driver::options::ClangFlags::DXCOption,
+    clang::driver::options::ClangFlags::FlangOnlyOption |
+        clang::driver::options::ClangFlags::FlangOption,
+};
+
 namespace {
 
 class DriverOptTable : public OptTable {
 public:
   DriverOptTable()
-    : OptTable(InfoTable) {}
+      : OptTable(InfoTable, /*IgnoreCase*/ false, MutuallyExclusiveFlags) {}
 };
 
 }

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -87,7 +87,8 @@ private:
                                           unsigned &Index) const;
 
 protected:
-  OptTable(ArrayRef<Info> OptionInfos, bool IgnoreCase = false);
+  OptTable(ArrayRef<Info> OptionInfos, bool IgnoreCase = false,
+           ArrayRef<unsigned> MutuallyExclusiveFlags = {});
 
 public:
   ~OptTable();


### PR DESCRIPTION
This is for case like -E option where both dxc and cl use same option with same prefix.
To allow it, an ArrayRef<unsigned> MutuallyExclusiveFlags is send to constructor of OptTable.
When confirm that options are in order, if 2 options are mutually exclusive, return true even they're Equivalent in name and prefix.